### PR TITLE
Playback page, Database, Recording page bug fixes

### DIFF
--- a/mobile/voice_journal_app/lib/Emotions_enums.dart
+++ b/mobile/voice_journal_app/lib/Emotions_enums.dart
@@ -1,10 +1,9 @@
 // ignore: file_names
-enum Emotions{
-  sad,
-  happy,
-  fear,
-  contempt,
-  surprise,
-  anger,
-  disgust
+enum Emotions {
+ 	happiness, // id = 0
+  sadness, // id = 1
+  anger, // id = 2
+  fear, // id = 3
+  disgust, // id = 4
+  surprise, // id = 5
 }

--- a/mobile/voice_journal_app/lib/Emotions_enums.dart
+++ b/mobile/voice_journal_app/lib/Emotions_enums.dart
@@ -1,0 +1,10 @@
+// ignore: file_names
+enum Emotions{
+  sad,
+  happy,
+  fear,
+  contempt,
+  surprise,
+  anger,
+  disgust
+}

--- a/mobile/voice_journal_app/lib/Playback.dart
+++ b/mobile/voice_journal_app/lib/Playback.dart
@@ -6,7 +6,6 @@ import 'schema.dart';
 //----Initializing vairables----
 String title ='';
 String audioFile ='';
-Icon stateIcon = const Icon(Icons.play_arrow);
 bool playing = false;
 late PlayerController controller;
 int duration = 0;
@@ -23,13 +22,9 @@ displayRecording(Recording givenRecording) async{ //function to get information 
   audioPlayerPrep(); //Initialize the audio player
 }
 playbackRecording()async { //play the playback
-  playing = true;
-  stateIcon = const Icon(Icons.pause);
   await controller.startPlayer(finishMode: FinishMode.loop); //start playback, loop recording when we get to the end of it.
 }
 pauseRecording()async { //pause the playback
-  playing = false;
-  stateIcon = const Icon(Icons.play_arrow);
   await controller.pausePlayer(); //pause recording
 }
 audioPlayerPrep()async{ //initialize the audio player
@@ -51,7 +46,7 @@ class _PlaybackPageState extends State<PlaybackPage>{
   @override
   initState(){ //Page Initialization code, moved frome changed state.
     super.initState();
-    controller.onCompletion.listen((event){ pauseRecording(); setState((){});}); //add a listener so that when the file ends it pauses. This allows the user to loop their recording as many times as they want, but they just have to hit the play button to do so
+    controller.onCompletion.listen((event){ pauseRecording(); setState((){playing = !playing;});}); //add a listener so that when the file ends it pauses. This allows the user to loop their recording as many times as they want, but they just have to hit the play button to do so
   }
   changeState(){
     if(playing){ //If the recording is playing
@@ -60,6 +55,7 @@ class _PlaybackPageState extends State<PlaybackPage>{
       playbackRecording(); //play it
     }
     setState(() { //visual update for the pause and play button
+      playing = !playing;
     });
   }
   @override
@@ -126,7 +122,6 @@ class _PlaybackPageState extends State<PlaybackPage>{
                   controller.stopAllPlayers();
                   controller.dispose();
                   playing = false;
-                  stateIcon = const Icon(Icons.play_arrow);
                 }
               }, child: const Text(' '),
             )
@@ -144,7 +139,7 @@ class _PlaybackPageState extends State<PlaybackPage>{
           tooltip: 'Record',
           backgroundColor: AppColors.accentColor, //button background colour
           splashColor: Colors.red[200],     //button click animation
-          child: stateIcon,
+          child: playing ? const Icon(Icons.pause) : const Icon(Icons.play_arrow),
         ),
       ),
     floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked, // Centers the button above the bar

--- a/mobile/voice_journal_app/lib/Playback.dart
+++ b/mobile/voice_journal_app/lib/Playback.dart
@@ -1,0 +1,157 @@
+import 'package:audio_waveforms/audio_waveforms.dart'; //for recording and waveforms
+import 'theme.dart';
+import 'package:flutter/material.dart';
+import 'schema.dart';
+//----Initializing vairables----
+String title ='';
+String audioFile ='';
+Icon stateIcon = const Icon(Icons.play_arrow);
+bool playing = false;
+bool listening = false;
+late PlayerController controller;
+int durration = 0;
+//----Done Initializing variables----
+
+DisplayRecording(Recording givenRecording) async{ //function to get information out of the recording being shown
+  title = givenRecording.title;
+  audioFile = givenRecording.audioFile;
+  durration = givenRecording.durration;
+  if(givenRecording.isTranscribed){
+    //get transcription file here.
+  }
+  controller = PlayerController();
+  audioPlayerPrep(); //Initialize the audio player
+}
+playbackRecording()async { //play the playback
+  playing = true;
+  stateIcon = const Icon(Icons.pause);
+  await controller.startPlayer(finishMode: FinishMode.loop); //start playback, loop recording when we get to the end of it.
+}
+pauseRecording()async { //pause the playback
+  playing = false;
+  stateIcon = const Icon(Icons.play_arrow);
+  await controller.pausePlayer(); //pause recording
+}
+audioPlayerPrep()async{ //initialize the audio player
+  await controller.preparePlayer( //prepare it
+    path: audioFile, //fetch the given file
+    shouldExtractWaveform: true, //Get the sound wave
+    noOfSamples: 50, //how big the sound wave is
+    volume: 10, //how loud it is
+  );
+  controller.updateFrequency = UpdateFrequency.medium; //controller visual update speed
+}
+void main(){
+  runApp(const PlaybackPage(title: 'playback Page'));
+}
+class PlaybackPage extends StatefulWidget{
+  const PlaybackPage({super.key, required this.title});
+  final String title;
+  @override
+  State<PlaybackPage> createState() => _PlaybackPageState();
+}
+class _PlaybackPageState extends State<PlaybackPage>{
+  changeState(){
+    if(!listening){ //if this is the first time the button is being pressed
+      controller.onCompletion.listen((event){ pauseRecording(); setState((){});}); //add a listener so that when the file ends it pauses. This allows the user to loop their recording as many times as they want, but they just have to hit the play button to do so
+      listening = true; //Set the bool so we dont do this again.
+    }
+    if(playing){ //If the recording is playing
+      pauseRecording(); //pause it
+    } else{ //if the recording is not playing
+      playbackRecording(); //play it
+    }
+    setState(() { //visual update for the pause and play button
+    });
+  }
+  @override
+  Widget build(BuildContext context) {
+    //audioPlayerPrep();
+    return Scaffold(
+      body: Center(
+        child: Column(
+          children: <Widget>[
+            AppBar(
+              backgroundColor: AppColors.lightGray,
+              title: Text(title),
+            ), //Creating an app bar to have the back button on the top of the page
+            const SizedBox(height: 40),
+            Container(
+              alignment: Alignment.center,
+              width: 370,
+              height: 200,
+              decoration: BoxDecoration(
+                color: AppColors.secondaryColor,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[ 
+                  if(durration > 1)
+                  AudioFileWaveforms(
+                    size: Size(MediaQuery.of(context).size.width, 200.00),
+                    playerController: controller,
+                    waveformType: WaveformType.long,
+                    playerWaveStyle: const PlayerWaveStyle(
+                      fixedWaveColor: AppColors.accentColor,
+                      liveWaveColor: AppColors.pastelYellow,
+                      spacing: 4,
+                    ),
+                  ),
+                  if(durration < 1)
+                  const Text('File is too small to display waveform')
+                ],
+              ),
+            ),  
+            const SizedBox(height: 30),
+            Container( //Will be used to display how far in the recording we've played so far.
+              alignment: Alignment.center,
+              width: 370,
+              height: 350,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: AppColors.primaryColor,
+                borderRadius: BorderRadius.circular(20),
+              ),
+                child: 
+                const Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children:[
+                    Text('Transcript will go here'),
+                  ]
+                ),
+            ),
+            PopScope(
+              canPop:true,
+              onPopInvoked: (bool didPop){
+                if(didPop){
+                  listening = false;
+                  controller.stopAllPlayers();
+                  controller.dispose();
+                  playing = false;
+                  stateIcon = const Icon(Icons.play_arrow);
+                }
+              }, child: const Text(' '),
+            )
+          ],
+        ),
+      ),
+      floatingActionButton: Container( //Recording button
+        alignment: Alignment.bottomCenter,
+        margin: const EdgeInsets.only(bottom: 120),
+        height: 70,
+        width:70,
+        // alignment: Alignment.center,
+        child: FloatingActionButton(
+          onPressed: changeState,
+          tooltip: 'Record',
+          backgroundColor: AppColors.accentColor, //button background colour
+          splashColor: Colors.red[200],     //button click animation
+          child: stateIcon,
+        ),
+      ),
+    floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked, // Centers the button above the bar
+    );
+  }
+
+}

--- a/mobile/voice_journal_app/lib/RecordingPage.dart
+++ b/mobile/voice_journal_app/lib/RecordingPage.dart
@@ -2,26 +2,37 @@ import 'dart:async'; //Required for recording and waitting.
 import 'dart:io';
 import 'package:flutter/material.dart'; //
 import 'package:audio_waveforms/audio_waveforms.dart'; //for recording and waveforms
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart'; //Used for date formatting
 import 'package:path_provider/path_provider.dart'; //used for getting app directory
-import 'package:fluttertoast/fluttertoast.dart';
-import 'package:voice_journal_app/main.dart'; //Used for making saved pop up
+import 'package:fluttertoast/fluttertoast.dart'; //Used for making saved pop up
+import 'package:voice_journal_app/Emotions_enums.dart';
+import 'package:voice_journal_app/home.dart';
+import 'package:voice_journal_app/theme.dart'; 
+import 'schema.dart';
 // To-do List:
 // - Save file (Done)
-// - Recording to data base (Not Done) 
-// - Send the audio file to API (Not Done Have not looked into Hive yet)
+// - Recording to data base (Done) 
+// - Send the audio file to API (Not Done)
 // ------Initializing Variables----
 RecorderController controller = RecorderController();
 String path = '';
-late DateTime presently; //what day/time is it presently? went with the shortest name I could think of
+DateTime presently = DateTime.now(); //what day/time is it presently? went with the shortest name I could think of
 int secondsCounter = 0;
 late Timer _timer;
 String message = "Press the record button to start";
+bool boxCreated = false;
 Icon rcrdIcon = const Icon(Icons.mic_off_outlined);  
+bool recordingStarted = false;
 bool recording = false; //Establish a bool to keep track of button state
 bool transcribed = false; //Transcribed bool **just a placeholder for now**
 late Directory appDirectory; //late meanning initializing later in code, but deffining it now
 bool counting = false; //Counting bool to track if the counter has been started or not. Unsure if I can stop it so this bool is used to prevent double trigger (counting on 2s)
+String formattedDateTime = DateFormat('yyy-MM-dd-HH-mm-ss').format(presently); //Format date and time to work as a valid file name
+String file = '$formattedDateTime.m4a'; //definning title for look up.
+late Recording currentRecording;
+late var rbox; //openj recording box (rbox)
 // ------Done Initializing Variables----
 void displaySaved(){ //Create a little pop up letting the user know their reccording has been saved
   Fluttertoast.showToast(
@@ -35,30 +46,35 @@ void displaySaved(){ //Create a little pop up letting the user know their reccor
   );
 }
 startRecording() async{
+  controller.bitRate = 192000;
+  controller.sampleRate = 50000;
   rcrdIcon = const Icon(Icons.pause);
-  recording = true;
-  final hasPermission = await controller.checkPermission(); //get permission to use mic
-  //appDirectory = await getApplicationDocumentsDirectory();  //get the apps directory useful later
-  appDirectory = Directory('/storage/emulated/0/Download'); //Set directory for file to go to
+  appDirectory = await getApplicationDocumentsDirectory();  //get the apps directory useful later
+  //appDirectory = Directory('/storage/emulated/0/Download'); //Set directory for file to go to
   String exactDirectory = appDirectory.path;
-  presently = DateTime.now(); //Set presently string to date and time
-  String formattedDateTime = DateFormat('yyy-MM-dd-HH-mm-ss').format(presently); //Format date and time to work as a valid file name
-  path = '$exactDirectory' +'/$formattedDateTime.m4a';//Set the path to where it should go + the current date and time
-  if(hasPermission){ //If we got phone permissions
-    controller.record(path: path); //Record
-  }
+  path = '$exactDirectory' '/$file';//Set the path to where it should go + the current date and time formatting with .m4a at the end
+  recording = true; 
+  //rbox = await Hive.openBox<Recording>('recordings'); //open the box so we can put things inside of it.
+  rbox = Hive.box<Recording>('recordings');
+  currentRecording = Recording(id: 'api call',title: formattedDateTime,audioFile: path,transcriptFile: 'api call',timeStamp: presently,emotion: Emotions.happy,isTranscribed: false,transcriptionId:'api call', durration: 0); //create the recording class
+  controller.record(path: path); //Actually start the recording
   message = 'Recording'; //change message to show recording
 }
-stopRecording(){
-  if(counting){
+stopRecording() async{
+  controller.stop();
+  //controller.dispose();
+  if(counting){ //if the timer was started
     counting = false;//Don't count anymore
     _timer.cancel();
   }
-    recording = false; //No longer recording
-    controller.stop(); //Stop the recording controller
-    secondsCounter = 0; //reset counter to 0
-    rcrdIcon = const Icon(Icons.mic_off_outlined);  
-    message = 'Recording Stopped';
+  if(secondsCounter > 2){ //if something was recorded that's longer than a second then add it to the data base.
+    currentRecording.durration = secondsCounter;
+    await rbox.add(currentRecording); //Add the recording to the database
+  }
+  recording = false; //No longer recording
+  secondsCounter = 0; //reset counter to 0
+  rcrdIcon = const Icon(Icons.mic_off_outlined);  
+  message = 'Recording Stopped';
 }
 pauseRecording(){
   recording = false; //not recording
@@ -67,27 +83,36 @@ pauseRecording(){
   message = 'Recording paused';
   displaySaved();
 }
+void main() async{
+  runApp(const MaterialApp(home: HomePage())); //Run the homepage if this page is ran on its own
+}
 class RecordingPage extends StatefulWidget{
-  const RecordingPage({super.key, required this.title});
+  const RecordingPage({super.key, required this.title, required this.callback}); //takes in call back function to call when this page is closed, this refreashes the widget tree on the homepage to update the recent recordings list.
   final String title;
+  final VoidCallback callback;
   @override
   State<RecordingPage> createState() => _RecordingPageState();
 }
 class _RecordingPageState extends State<RecordingPage>{
   void _changeState() async{
-    if(!recording){ //if currently not recording and the button has been hit`
-      recording = true; //recording is true
-      await startRecording(); //wait for function to start the recording
-      if(!counting){
-        _startCounting(); //Starts the displayed recording counter
+    final hasPermission = await controller.checkPermission(); //get permission to use mic
+    if(hasPermission){
+      if(!recording){ //if currently not recording and the button has been hit`
+        //recording = true; //recording is true
+        await startRecording(); //wait for function to start the recording
+        if(!counting){
+          _startCounting(); //Starts the displayed recording counter
+        }
+        setState(() { //change state (icon of the button should change)
+        });
+      } else if(recording){ //else if we are recording and the button was hit
+        //recording = false; //stop recording
+        await pauseRecording();
+        setState(() { //set state (change button icon)
+        });
       }
-      setState(() { //change state (icon of the button should change)
-      });
-    } else if(recording){ //else if we are recording and the button was hit
-      recording = false; //stop recording
-      await pauseRecording();
-      setState(() { //set state (change button icon)
-      });
+    } else{
+      message = 'permissions denied, no recording allowed';
     }
   }
   void _startCounting(){ //start timer
@@ -109,15 +134,14 @@ class _RecordingPageState extends State<RecordingPage>{
        child: Column(
             //mainAxisAlignment: MainAxisAlignment.center, //center it
             children: <Widget>[
-              const SizedBox(height: 20), // Add some spacing
-              const SizedBox(height: 20), // Add some spacing
+              const SizedBox(height: 40), // Add some spacing
               Container( //Container at the top of the page showing timer and recording status
                 alignment: Alignment.center, //center align
                 width: 370,
                 height: 200,
                 padding: const EdgeInsets.all(10),
                 decoration: BoxDecoration(
-                color: Colors.orange[100],
+                color: AppColors.secondaryColor,
                 borderRadius: BorderRadius.circular(20),
                 ),
                 child: 
@@ -133,11 +157,12 @@ class _RecordingPageState extends State<RecordingPage>{
               ),
               const SizedBox(height: 30), //spacer
               Container( //This is the lower box which displays the audio waveforms.
+                alignment: Alignment.center,
                 width: 370,
                 height:200,
                 padding: const EdgeInsets.all(10),
                 decoration: BoxDecoration(
-                color: Colors.blue[400],
+                color: AppColors.primaryColor,
                 borderRadius: BorderRadius.circular(20),
                 ),
                 child: 
@@ -146,7 +171,7 @@ class _RecordingPageState extends State<RecordingPage>{
                     recorderController: controller,
                     enableGesture: false,//makes it so you cant move around the waves by dragging your finger
                     waveStyle: const WaveStyle( //controls how the wave looks
-                      waveColor: Colors.white,
+                      waveColor: AppColors.mutedTeal,
                       showDurationLabel: false,
                       spacing: 4.0, //increase wave resolution/definition/ammount
                       showBottom: true, //Unsure what this does
@@ -155,12 +180,21 @@ class _RecordingPageState extends State<RecordingPage>{
                   ),
                 ),
               ),
+              PopScope(
+                canPop: true,
+                onPopInvoked: (bool didPop) async{
+                  if(didPop){ //If the page has been closed
+                        await stopRecording(); //Then stop the recording
+                        widget.callback();
+                    return;
+                  }
+                }, child: const Text(''),
+              )
             ],
           ),
         ),
         appBar: AppBar(
-
-          
+          backgroundColor: AppColors.lightGray,
         ),
       floatingActionButton: Container( //Recording button
         margin: const EdgeInsets.only(bottom: 120),
@@ -170,8 +204,8 @@ class _RecordingPageState extends State<RecordingPage>{
         child: FloatingActionButton(
           onPressed: _changeState,
           tooltip: 'Record',
-          backgroundColor: Colors.red[200], //button background colour
-          splashColor: Colors.red[500],     //button click animation
+          backgroundColor: AppColors.accentColor, //button background colour
+          splashColor: Colors.red[200],     //button click animation
           child: rcrdIcon,
         ),
       ),

--- a/mobile/voice_journal_app/lib/RecordingPage.dart
+++ b/mobile/voice_journal_app/lib/RecordingPage.dart
@@ -18,7 +18,7 @@ import 'schema.dart';
 // ------Initializing Variables----
 RecorderController controller = RecorderController();
 String path = '';
-DateTime presently = DateTime.now(); //what day/time is it presently? went with the shortest name I could think of
+late DateTime presently; //what day/time is it presently? went with the shortest name I could think of
 int secondsCounter = 0;
 late Timer _timer;
 String message = "Press the record button to start";
@@ -29,8 +29,8 @@ bool recording = false; //Establish a bool to keep track of button state
 bool transcribed = false; //Transcribed bool **just a placeholder for now**
 late Directory appDirectory; //late meanning initializing later in code, but deffining it now
 bool counting = false; //Counting bool to track if the counter has been started or not. Unsure if I can stop it so this bool is used to prevent double trigger (counting on 2s)
-String formattedDateTime = DateFormat('yyy-MM-dd-HH-mm-ss').format(presently); //Format date and time to work as a valid file name
-String file = '$formattedDateTime.m4a'; //definning title for look up.
+late String formattedDateTime; //Format date and time to work as a valid file name
+late String file; //definning title for look up.
 late Recording currentRecording;
 late var rbox; //openj recording box (rbox)
 // ------Done Initializing Variables----
@@ -46,6 +46,9 @@ void displaySaved(){ //Create a little pop up letting the user know their reccor
   );
 }
 startRecording() async{
+  presently = DateTime.now();
+  formattedDateTime = DateFormat('yyy-MM-dd-HH-mm-ss').format(presently);
+  file = '$formattedDateTime.m4a';
   controller.bitRate = 192000;
   controller.sampleRate = 50000;
   rcrdIcon = const Icon(Icons.pause);

--- a/mobile/voice_journal_app/lib/RecordingPage.dart
+++ b/mobile/voice_journal_app/lib/RecordingPage.dart
@@ -59,7 +59,7 @@ startRecording() async{
   recording = true; 
   //rbox = await Hive.openBox<Recording>('recordings'); //open the box so we can put things inside of it.
   rbox = Hive.box<Recording>('recordings');
-  currentRecording = Recording(id: 'api call',title: formattedDateTime,audioFile: path,transcriptFile: 'api call',timeStamp: presently,emotion: Emotions.happy,isTranscribed: false,transcriptionId:'api call', durration: 0); //create the recording class
+  currentRecording = Recording(id: '',title: formattedDateTime,audioFile: path,transcriptFile: '',timeStamp: presently,emotion:[Emotions.happy, Emotions.anger],isTranscribed: false,transcriptionId:'', duration: 0); //create the recording class
   controller.record(path: path); //Actually start the recording
   message = 'Recording'; //change message to show recording
 }
@@ -71,7 +71,7 @@ stopRecording() async{
     _timer.cancel();
   }
   if(secondsCounter > 2){ //if something was recorded that's longer than a second then add it to the data base.
-    currentRecording.durration = secondsCounter;
+    currentRecording.duration = secondsCounter;
     await rbox.add(currentRecording); //Add the recording to the database
   }
   recording = false; //No longer recording

--- a/mobile/voice_journal_app/lib/RecordingPage.dart
+++ b/mobile/voice_journal_app/lib/RecordingPage.dart
@@ -23,7 +23,6 @@ int secondsCounter = 0;
 late Timer _timer;
 String message = "Press the record button to start";
 bool boxCreated = false;
-Icon rcrdIcon = const Icon(Icons.mic_off_outlined);  
 bool recordingStarted = false;
 bool recording = false; //Establish a bool to keep track of button state
 bool transcribed = false; //Transcribed bool **just a placeholder for now**
@@ -51,15 +50,14 @@ startRecording() async{
   file = '$formattedDateTime.m4a';
   controller.bitRate = 192000;
   controller.sampleRate = 50000;
-  rcrdIcon = const Icon(Icons.pause);
   appDirectory = await getApplicationDocumentsDirectory();  //get the apps directory useful later
   //appDirectory = Directory('/storage/emulated/0/Download'); //Set directory for file to go to
   String exactDirectory = appDirectory.path;
   path = '$exactDirectory' '/$file';//Set the path to where it should go + the current date and time formatting with .m4a at the end
-  recording = true; 
   //rbox = await Hive.openBox<Recording>('recordings'); //open the box so we can put things inside of it.
+  await Hive.openBox<Recording>('recordings');
   rbox = Hive.box<Recording>('recordings');
-  currentRecording = Recording(id: '',title: formattedDateTime,audioFile: path,transcriptFile: '',timeStamp: presently,emotion:[Emotions.happy, Emotions.anger],isTranscribed: false,transcriptionId:'', duration: 0); //create the recording class
+  currentRecording = Recording(id: '',title: formattedDateTime,audioFile: path,transcriptFile: '',timeStamp: presently,emotion:[],isTranscribed: false,transcriptionId:'', duration: 0); //create the recording class
   controller.record(path: path); //Actually start the recording
   message = 'Recording'; //change message to show recording
 }
@@ -74,20 +72,14 @@ stopRecording() async{
     currentRecording.duration = secondsCounter;
     await rbox.add(currentRecording); //Add the recording to the database
   }
-  recording = false; //No longer recording
   secondsCounter = 0; //reset counter to 0
-  rcrdIcon = const Icon(Icons.mic_off_outlined);  
   message = 'Recording Stopped';
+  Hive.close();
 }
 pauseRecording(){
-  recording = false; //not recording
   controller.pause(); //pause the recording
-  rcrdIcon = const Icon(Icons.play_arrow);
   message = 'Recording paused';
   displaySaved();
-}
-void main() async{
-  runApp(const MaterialApp(home: HomePage())); //Run the homepage if this page is ran on its own
 }
 class RecordingPage extends StatefulWidget{
   const RecordingPage({super.key, required this.title, required this.callback}); //takes in call back function to call when this page is closed, this refreashes the widget tree on the homepage to update the recent recordings list.
@@ -106,14 +98,13 @@ class _RecordingPageState extends State<RecordingPage>{
         if(!counting){
           _startCounting(); //Starts the displayed recording counter
         }
-        setState(() { //change state (icon of the button should change)
-        });
       } else if(recording){ //else if we are recording and the button was hit
         //recording = false; //stop recording
         await pauseRecording();
-        setState(() { //set state (change button icon)
-        });
       }
+      setState(() { //set state (change button icon)
+        recording = !recording;
+      });
     } else{
       message = 'permissions denied, no recording allowed';
     }
@@ -209,7 +200,7 @@ class _RecordingPageState extends State<RecordingPage>{
           tooltip: 'Record',
           backgroundColor: AppColors.accentColor, //button background colour
           splashColor: Colors.red[200],     //button click animation
-          child: rcrdIcon,
+          child: recording ? const Icon(Icons.pause) : const Icon(Icons.play_arrow),
         ),
       ),
     floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked, // Centers the button above the bar

--- a/mobile/voice_journal_app/lib/home.dart
+++ b/mobile/voice_journal_app/lib/home.dart
@@ -67,7 +67,7 @@ class HomePageState extends State<HomePage>{
                         ? TextButton(
                             onPressed: () {
                               if(recording != (null)){
-                              DisplayRecording(recording);
+                              displayRecording(recording);
                                 Navigator.push(
                                   context,
                                   MaterialPageRoute(builder: (context) => const PlaybackPage(title: 'playback page')),

--- a/mobile/voice_journal_app/lib/home.dart
+++ b/mobile/voice_journal_app/lib/home.dart
@@ -1,77 +1,115 @@
 import 'package:flutter/material.dart';
+import 'package:voice_journal_app/Playback.dart';
 import 'theme.dart';
 import 'RecordingPage.dart';
+import 'package:hive/hive.dart'; //Importing the local database
+import 'package:hive_flutter/hive_flutter.dart';
+import 'schema.dart';
 
-class HomePage extends StatelessWidget {
+//init variables
+bool boxOpened = false;
+var rbox = Hive.box<Recording>('recordings');
+//end of variables
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+  @override
+  State<HomePage> createState() => HomePageState();
+}
+class HomePageState extends State<HomePage>{
+  void updateList(){
+    setState(() {
+      
+    });
+  }
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16.0), // Horizontal padding for white space
-        child: Container(
-          padding: const EdgeInsets.only(bottom: 60.0, top: 90.0), // Adjusted to accommodate FAB and title
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.end, // Aligns children to the bottom
-            crossAxisAlignment: CrossAxisAlignment.stretch, // Stretches children horizontally to match the column width
-            children: <Widget>[
-              Text(
-                'Emoz',
-                textAlign: TextAlign.center, //
-                style: TextStyle(
-                  fontSize: 24, 
-                  fontWeight: FontWeight.bold, 
-                  color: Colors.black, 
-                ),
-              ),
-              SizedBox(height: 20), // Adds space between the title and the first container
-              Container(
-                height: 200,
-                decoration: BoxDecoration(
-                  color: AppColors.secondaryColor, // Background color
-                  borderRadius: BorderRadius.circular(10), // Rounds corners
-                ),
-                child: Center(child: Text('Emotion Stats')), // Placeholder text
-                margin: EdgeInsets.only(bottom: 20, top: 20), // Space between the rectangles and additional top padding
-              ),
-              Expanded( // 
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: AppColors.primaryColor, // Background color of the rectangle
-                    borderRadius: BorderRadius.circular(10), // Rounded corners
+          padding: const EdgeInsets.symmetric(horizontal: 16.0), // Horizontal padding for white space
+          child: Container(
+            padding: const EdgeInsets.only(bottom: 60.0, top: 90.0), // Adjusted to accommodate FAB and title
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end, // Aligns children to the bottom
+              crossAxisAlignment: CrossAxisAlignment.stretch, // Stretches children horizontally to match the column width
+              children: <Widget>[
+                const Text(
+                  'Emoz',
+                  textAlign: TextAlign.center, //
+                  style: TextStyle(
+                    fontSize: 24, 
+                    fontWeight: FontWeight.bold, 
+                    color: Colors.black, 
                   ),
-                  child: ListView.builder( 
-                    itemCount: 10, // Number of items in the list, for demonstration
-                    itemBuilder: (context, index) => ListTile(
-                      title: Text('Item $index'), // Example list item
+                ),
+                const SizedBox(height: 20), // Adds space between the title and the first container
+                Container(
+                  height: 200,
+                  decoration: BoxDecoration(
+                    color: AppColors.secondaryColor, // Background color
+                    borderRadius: BorderRadius.circular(10), // Rounds corners
+                  ), // Placeholder text
+                  margin: const EdgeInsets.only(bottom: 20, top: 20),
+                  child: const Center(child: Text('Emotion Stats')), // Space between the rectangles and additional top padding
+                ),
+                Expanded( // 
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: AppColors.primaryColor, // Background color of the rectangle
+                      borderRadius: BorderRadius.circular(10), // Rounded corners
+                    ),
+                    child: ListView.builder( 
+                      itemCount: rbox.length, // Number of items in the list, for demonstration
+                      itemBuilder: (context, index){
+                      int reversedIndex = rbox.length - 1 - index;
+                      final recording = rbox.getAt(reversedIndex);
+                      return ListTile(
+                    title: recording != null
+                        ? TextButton(
+                            onPressed: () {
+                              if(recording != (null)){
+                              DisplayRecording(recording);
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(builder: (context) => const PlaybackPage(title: 'playback page')),
+                                );
+                              }
+                            },
+                            style: ButtonStyle(
+                              foregroundColor: MaterialStateProperty.all<Color>(AppColors.lightGray),
+                              backgroundColor: MaterialStateProperty.all<Color>(AppColors.mutedTeal),
+                            ),
+                            child: Text(recording.title),
+                          )
+                        : const Text('No recording available'),
+                       );
+                      },
                     ),
                   ),
                 ),
-              ),
+              ],
+            ),
+          ),
+        ),
+        bottomNavigationBar: BottomAppBar(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround, // Spaces icons evenly
+            children: <Widget>[
+              IconButton(icon: const Icon(Icons.auto_graph), onPressed: () {}),
+              IconButton(icon: const Icon(Icons.home), onPressed: () {}),
+              IconButton(icon: const Icon(Icons.date_range), onPressed: () {}),
             ],
           ),
         ),
-      ),
-      bottomNavigationBar: BottomAppBar(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround, // Spaces icons evenly
-          children: <Widget>[
-            IconButton(icon: Icon(Icons.auto_graph), onPressed: () {}),
-            IconButton(icon: Icon(Icons.home), onPressed: () {}),
-            IconButton(icon: Icon(Icons.date_range), onPressed: () {}),
-          ],
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+              Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => RecordingPage(title: 'recording page', callback: updateList)),
+                );
+            },
+          backgroundColor: AppColors.accentColor,
+          child: const Icon(Icons.add_circle_rounded),
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-            Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => const RecordingPage(title: 'recording page')),
-              );
-          },
-        child: Icon(Icons.add_circle_rounded),
-        backgroundColor: AppColors.accentColor,
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat, 
-    );
+      );
   }
 }

--- a/mobile/voice_journal_app/lib/main.dart
+++ b/mobile/voice_journal_app/lib/main.dart
@@ -7,7 +7,7 @@ import 'schema.dart';
 void main()async { 
   await Hive.initFlutter(); //Initialize hive for flutter crucial step
   Hive.registerAdapter(RecordingAdapter()); //Register the adapter, essentially telling Hive how to read and write our Recording information into a box
-  await Hive.openBox<Recording>('recordings');
+  //await Hive.openBox<Recording>('recordings');
   runApp(const MyApp());
 }
 class MyApp extends StatelessWidget {

--- a/mobile/voice_journal_app/lib/main.dart
+++ b/mobile/voice_journal_app/lib/main.dart
@@ -1,17 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:voice_journal_app/theme.dart';
 import 'home.dart';
-import 'theme.dart';
-
-void main() {
+import 'package:hive_flutter/hive_flutter.dart';
+import 'schema.dart';
+ 
+void main()async { 
+  await Hive.initFlutter(); //Initialize hive for flutter crucial step
+  Hive.registerAdapter(RecordingAdapter()); //Register the adapter, essentially telling Hive how to read and write our Recording information into a box
+  await Hive.openBox<Recording>('recordings');
   runApp(const MyApp());
 }
-
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   // This widget is the root of your application.
-  @override
+@override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'EMOZ', // Your app title
@@ -23,14 +26,14 @@ class MyApp extends StatelessWidget {
           // Define other custom colors as needed
         ),
         // Customize other theme properties based on AppColors
-        floatingActionButtonTheme: FloatingActionButtonThemeData(
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
           backgroundColor: AppColors.accentColor, // Custom FAB color
         ),
         scaffoldBackgroundColor: AppColors.lightGray, // Background color for Scaffold widgets
         // Add more theme customization as needed
         useMaterial3: true, // Opt-in to use Material 3 features
       ),
-      home: HomePage(),
+      home: const HomePage(),
     );
   }
 }

--- a/mobile/voice_journal_app/lib/schema.dart
+++ b/mobile/voice_journal_app/lib/schema.dart
@@ -86,19 +86,17 @@ _readEmotionsList(BinaryReader reader) {
   Emotions _getEmotionFromValue(int value) { //get emotions from a int value from enum
     switch (value) {
       case 0:
-        return Emotions.sad;
+        return Emotions.happiness;
       case 1:
-        return Emotions.happy;
+        return Emotions.sadness;
       case 2:
-        return Emotions.fear;
-      case 3:
-        return Emotions.contempt;
-      case 4:
-        return Emotions.surprise;
-      case 5:
         return Emotions.anger;
-      case 6:
+      case 3:
+        return Emotions.fear;
+      case 4:
         return Emotions.disgust;
+      case 5:
+        return Emotions.surprise;
       default:
         throw Exception('Invalid emotion value');
     }

--- a/mobile/voice_journal_app/lib/schema.dart
+++ b/mobile/voice_journal_app/lib/schema.dart
@@ -1,0 +1,67 @@
+import 'package:hive/hive.dart'; //Importing the local database
+import 'package:voice_journal_app/Emotions_enums.dart';
+ //----Start Of Database Setup----
+@HiveType(typeId:0)
+class Recording extends HiveObject{ //creating object class for database
+    @HiveField(0) //declaring fields
+    String id;
+    @HiveField(1)
+    String title;
+    @HiveField(2)
+    String audioFile;
+    @HiveField(3)
+    String transcriptFile;
+    @HiveField(4)
+    DateTime timeStamp;
+    @HiveField(5)
+    Emotions emotion;
+    @HiveField(6)
+    bool isTranscribed;
+    @HiveField(7)
+    String transcriptionId;
+    @HiveField(8)
+    int durration;
+    Recording({ //Declaring the actual recording class.
+      required this.id, 
+      required this.title, 
+      required this.audioFile, 
+      required this.transcriptFile, 
+      required this.timeStamp, 
+      required this.emotion, 
+      required this.isTranscribed, 
+      required this.transcriptionId,
+      required this.durration
+  });
+}
+class RecordingAdapter extends TypeAdapter<Recording>{ //create custom recording adapter, allows our database to interpret Recording class data.
+  @override
+  final typeId = 0;
+  @override
+  Recording read(BinaryReader reader){ //custom read function for the data base to allow it to read our specific class
+    return Recording(
+      id: reader.readString(),
+      title: reader.readString(),
+      audioFile: reader.readString(),
+      transcriptFile: reader.readString(),
+      timeStamp: reader.read(),
+      emotion: Emotions.values[reader.readInt()],
+      isTranscribed: reader.readBool(),
+      transcriptionId: reader.readString(),
+      durration: reader.readInt(),
+
+    );
+  }
+  @override
+  void write(BinaryWriter writer, Recording obj) { //specific write class to allow hive to write recording class data
+    writer.writeString(obj.id);
+    writer.writeString(obj.title);
+    writer.writeString(obj.audioFile);
+    writer.writeString(obj.transcriptFile);
+    writer.write(obj.timeStamp);
+    writer.writeInt(obj.emotion.index);
+    writer.writeBool(obj.isTranscribed);
+    writer.writeString(obj.transcriptionId);
+    writer.writeInt(obj.durration);
+  }
+}
+//----End of Database set up----

--- a/mobile/voice_journal_app/lib/schema.dart
+++ b/mobile/voice_journal_app/lib/schema.dart
@@ -14,13 +14,13 @@ class Recording extends HiveObject{ //creating object class for database
     @HiveField(4)
     DateTime timeStamp;
     @HiveField(5)
-    Emotions emotion;
+    List<Emotions> emotion = []; //List of emotions
     @HiveField(6)
     bool isTranscribed;
     @HiveField(7)
     String transcriptionId;
     @HiveField(8)
-    int durration;
+    int duration;
     Recording({ //Declaring the actual recording class.
       required this.id, 
       required this.title, 
@@ -30,7 +30,7 @@ class Recording extends HiveObject{ //creating object class for database
       required this.emotion, 
       required this.isTranscribed, 
       required this.transcriptionId,
-      required this.durration
+      required this.duration
   });
 }
 class RecordingAdapter extends TypeAdapter<Recording>{ //create custom recording adapter, allows our database to interpret Recording class data.
@@ -44,10 +44,10 @@ class RecordingAdapter extends TypeAdapter<Recording>{ //create custom recording
       audioFile: reader.readString(),
       transcriptFile: reader.readString(),
       timeStamp: reader.read(),
-      emotion: Emotions.values[reader.readInt()],
+      emotion: _readEmotionsList(reader),
       isTranscribed: reader.readBool(),
       transcriptionId: reader.readString(),
-      durration: reader.readInt(),
+      duration: reader.readInt(),
 
     );
   }
@@ -58,10 +58,51 @@ class RecordingAdapter extends TypeAdapter<Recording>{ //create custom recording
     writer.writeString(obj.audioFile);
     writer.writeString(obj.transcriptFile);
     writer.write(obj.timeStamp);
-    writer.writeInt(obj.emotion.index);
+    _writeEmotionsList(writer, obj.emotion);
     writer.writeBool(obj.isTranscribed);
     writer.writeString(obj.transcriptionId);
-    writer.writeInt(obj.durration);
+    writer.writeInt(obj.duration);
   }
+    void _writeEmotionsList(BinaryWriter writer, List<Emotions> emotionsList) {
+    writer.writeByte(emotionsList.length); // Write the list length
+
+    for (final emotion in emotionsList) {
+      writer.writeInt(emotion.index); // Store value of the integer
+    }
+  }
+_readEmotionsList(BinaryReader reader) {
+    final length = reader.readByte();
+    final emotionsList = <Emotions>[];
+
+    for (var i = 0; i < length; i++) {
+      final emotionValue = reader.readInt(); // Read the integer value
+      final emotion = _getEmotionFromValue(emotionValue); // Convert to Emotions object
+      emotionsList.add(emotion);
+    }
+
+    return emotionsList;
+  }
+
+  Emotions _getEmotionFromValue(int value) { //get emotions from a int value from enum
+    switch (value) {
+      case 0:
+        return Emotions.sad;
+      case 1:
+        return Emotions.happy;
+      case 2:
+        return Emotions.fear;
+      case 3:
+        return Emotions.contempt;
+      case 4:
+        return Emotions.surprise;
+      case 5:
+        return Emotions.anger;
+      case 6:
+        return Emotions.disgust;
+      default:
+        throw Exception('Invalid emotion value');
+    }
+  }
+
 }
 //----End of Database set up----

--- a/mobile/voice_journal_app/pubspec.lock
+++ b/mobile/voice_journal_app/pubspec.lock
@@ -120,6 +120,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.4"
+  hive:
+    dependency: "direct main"
+    description:
+      name: hive
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  hive_flutter:
+    dependency: "direct main"
+    description:
+      name: hive_flutter
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   intl:
     dependency: "direct main"
     description:

--- a/mobile/voice_journal_app/pubspec.yaml
+++ b/mobile/voice_journal_app/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
   intl: ^0.19.0
   fluttertoast: ^8.2.4
   permission_handler: ^11.3.0
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR features:
- Implementation of the data base
- Playback page
- the homepage now updates when a new recording is made. Displaying the mist recent recording without needing to restart the whole app. 
- Turned recording page which won't save any files to the data base that are less than 2 seconds in length. I also fixed the permissions button issue as well as streamlined a boolean variable which wasn't really needed.
- Cranked up the bitrate and the sample rate to create crispy ah hell audio. Recordings no longer sound like they were captured on a 1990 Blackberry phone.
- NO API YET (ill get there hopefully b4 tuesday)


> Play back page:

![image](https://github.com/LaurierCS/POD1/assets/109433535/d54de817-370b-4c4d-b2da-8356dfd4eb4e)

> Home page with recent recordings list

![image](https://github.com/LaurierCS/POD1/assets/109433535/f7012711-4b6e-4e47-912b-77890711ad91)

